### PR TITLE
Fix update of change mode on detach

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/tinymceConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/tinymceConnector.js
@@ -3,7 +3,7 @@ window.Vaadin.Flow.tinymceConnector = {
         // Check whether the connector was already initialized for the editor
         var readonlyTimeout;
         var currentValue = ta.innerHTML;
-        var changeMode = 'change';
+        var changeMode;
 
         var readonlyTimeout;
         if (c.$connector) {
@@ -11,6 +11,7 @@ window.Vaadin.Flow.tinymceConnector = {
 			// and re-init
 			c.$connector.editor.remove();
         } else {
+          changeMode = 'change';
           // Init connector at first visit
           c.$connector = {
           


### PR DESCRIPTION
This PR makes changes such that the change mode is not altered when the tinymce is detached and then attached. 